### PR TITLE
use tab.update instead of redirectUrl to vanish referer

### DIFF
--- a/background.js
+++ b/background.js
@@ -381,9 +381,7 @@ function maybeRedirect(requestDetails) {
     prepareToolbarContextMenu(requestDetails.url);
     notifySkip(requestDetails.url, redirectTarget);
 
-    return {
-        redirectUrl: redirectTarget,
-    };
+    browser.tabs.update(requestDetails.tabId, {url: redirectTarget});
 }
 
 function prepareToolbarContextMenu(from) {


### PR DESCRIPTION
Skip redirect by returning `redirectUrl` will increase some privacy risk.

Without this addon, clicking a link in `https://forum.com/post-xxxxxx` 
which is originally to `https://redirect.forum.com/dest=http://badsite.com`.
badsite.com can't see visitor's source postid from referer. The referer is just `https://redirect.forum.com/`.

After changing target url by returning a `redirectUrl`, the referer will expose visitor's source `https://forum.com/post-xxxxxx`

So, use `tab.update` to make referer empty
