### PR TITLE
add web.archive.org to default no-skip URLs list

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,6 +46,7 @@ const DEFAULT_NO_SKIP_PARAMETERS_LIST = [
 ];
 
 const DEFAULT_NO_SKIP_URLS_LIST = [
+    "web.archive.org/",
     "/abp",
     "/account",
     "/adfs",


### PR DESCRIPTION
Original behaviour redirected from Wayback Machine to archived URL; adding `web.archive.org/` to no-skip URLs list in extension settings fixes this and lets users stay on the Wayback Machine.

Before:
https://web.archive.org/web/20240425045640/https://en.wikipedia.org/wiki/Cheese

![image](https://github.com/sblask-webextensions/webextension-skip-redirect/assets/1901532/9e2469b4-30a9-431c-b27c-259fc413af4f)


Fixed with:
![image](https://github.com/sblask-webextensions/webextension-skip-redirect/assets/1901532/3b4525fa-966e-49ed-8edf-6bf12af0566a)
