### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
         "64": "icon-64x64.png",
         "128": "icon-128x128.png"
     },
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "__MSG_extensionName__",
     "options_ui": {
         "page": "options/options.html"


### PR DESCRIPTION
Currently, the extension is disabled by chrome after updating to the latestz version.
The Chrome extension webstore shows a message:
"This extension is no longer available because it doesn't follow best practices for Chrome extensions".

I've had a look at the migration documents, and found nothing that should not make it work with the manifest v3.
So, this tiny should be enough. I'd appreciate it if you tried this out, please. Thank you.